### PR TITLE
Add iOS 18 JIT

### DIFF
--- a/src/xenia/base/memory_posix.cc
+++ b/src/xenia/base/memory_posix.cc
@@ -284,6 +284,8 @@ bool Protect(void* base_address, size_t length, PageAccess access,
   return true;
 }
 
+extern void sys_icache_invalidate(void *start, size_t len);
+
 bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
 #if XE_PLATFORM_APPLE
   access_out = PageAccess::kNoAccess;
@@ -327,6 +329,10 @@ bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
   const bool can_read = (prot & VM_PROT_READ) != 0;
   const bool can_write = (prot & VM_PROT_WRITE) != 0;
   const bool can_execute = (prot & VM_PROT_EXECUTE) != 0;
+    
+    if (can_execute) {
+        sys_icache_invalidate(base_address, length);
+    }
 
   if (can_write) {
     access_out =

--- a/src/xenia/cpu/backend/a64/a64_code_cache.cc
+++ b/src/xenia/cpu/backend/a64/a64_code_cache.cc
@@ -483,6 +483,8 @@ bool RegionUnlockWrite(void* address, size_t length) {
 }
 
 bool RegionSetExec(void* address, size_t length) {
+    
+    
   return SetPageAlignedAccessWithExternalPrepareFallback(
       address, length, xe::memory::PageAccess::kExecuteReadOnly,
       "RX transition");
@@ -801,15 +803,15 @@ bool A64CodeCache::Initialize() {
       // For W^X flips, prefer starting from an RX mapping (so EXECUTE is
       // present in the mapping's max protections on iOS), then temporarily
       // switching pages to RW for writes.
-      generated_code_execute_base_ = reinterpret_cast<uint8_t*>(
-          mmap(nullptr, kGeneratedCodeSize, PROT_READ | PROT_EXEC,
+      generated_code_write_base_ = reinterpret_cast<uint8_t*>(
+          mmap(nullptr, kGeneratedCodeSize, PROT_READ | PROT_WRITE,
                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
-      if (generated_code_execute_base_ == MAP_FAILED) {
-        generated_code_execute_base_ = nullptr;
+      if (generated_code_write_base_ == MAP_FAILED) {
+          generated_code_write_base_ = nullptr;
         XELOGE("Unable to allocate iOS JIT code cache (RX mapping)");
         return false;
       }
-      generated_code_write_base_ = generated_code_execute_base_;
+      generated_code_execute_base_ = generated_code_write_base_;
       generated_code_uses_mprotect_flip_ = true;
       if (use_txm_broker_path) {
         XELOGI("iOS JIT mprotect-flip fallback active (TXM/broker path)");

--- a/src/xenia/cpu/backend/a64/a64_function.cc
+++ b/src/xenia/cpu/backend/a64/a64_function.cc
@@ -86,6 +86,57 @@ bool A64Function::CallImpl(ThreadState* thread_state, uint32_t return_address) {
   bool target_executable = is_executable(target_region_access);
   bool thunk_executable = is_executable(thunk_region_access);
 
+  // Attempt to fix non-executable regions
+  if (target_region_ok && !target_executable) {
+    XELOGW(
+        "A64 iOS JIT target not executable, attempting reprotect: "
+        "target={:p} current_access={} size=0x{:X}",
+        static_cast<void*>(machine_code_),
+        static_cast<uint32_t>(target_region_access),
+        static_cast<uint32_t>(target_region_size));
+    
+    // Try to reprotect to RX
+    if (xe::memory::Protect(machine_code_, target_region_size,
+                            xe::memory::PageAccess::kExecuteReadOnly)) {
+      target_region_ok = xe::memory::QueryProtect(
+          machine_code_, target_region_size, target_region_access);
+      target_executable = is_executable(target_region_access);
+      
+      if (target_executable) {
+        XELOGI("A64 iOS JIT target reprotect succeeded: new_access={}",
+               static_cast<uint32_t>(target_region_access));
+      }
+    } else {
+      XELOGE("A64 iOS JIT target reprotect failed");
+    }
+  }
+
+  if (thunk_region_ok && !thunk_executable) {
+    XELOGW(
+        "A64 iOS JIT thunk not executable, attempting reprotect: "
+        "thunk={:p} current_access={} size=0x{:X}",
+        reinterpret_cast<void*>(thunk),
+        static_cast<uint32_t>(thunk_region_access),
+        static_cast<uint32_t>(thunk_region_size));
+    
+    // Try to reprotect to RX
+    if (xe::memory::Protect(reinterpret_cast<void*>(thunk), thunk_region_size,
+                            xe::memory::PageAccess::kExecuteReadOnly)) {
+      // Verify the change took effect
+      thunk_region_ok = xe::memory::QueryProtect(
+          reinterpret_cast<void*>(thunk), thunk_region_size, thunk_region_access);
+      thunk_executable = is_executable(thunk_region_access);
+      
+      if (thunk_executable) {
+        XELOGI("A64 iOS JIT thunk reprotect succeeded: new_access={}",
+               static_cast<uint32_t>(thunk_region_access));
+      }
+    } else {
+      XELOGE("A64 iOS JIT thunk reprotect failed");
+    }
+  }
+
+  // Final check after attempting fixes
   if (!target_region_ok || !target_executable || !thunk_region_ok ||
       !thunk_executable) {
     static std::atomic<bool> logged_bad_jit_path{false};
@@ -128,9 +179,8 @@ bool A64Function::CallImpl(ThreadState* thread_state, uint32_t return_address) {
         static_cast<uint32_t>(target_region_size),
         static_cast<uint32_t>(target_region_access), thunk_insn, target_insn);
   }
-#endif
+#endif  // XE_PLATFORM_IOS && defined(__aarch64__)
 
-  // Make the actual thunk call
   auto* code = machine_code_.load(std::memory_order_acquire);
   thunk(code, thread_state->context(),
         reinterpret_cast<void*>(uintptr_t(return_address)));


### PR DESCRIPTION
Adds iOS 18 and below W^X JIT by making a `PROT_READ | PROT_WRITE` map first instead of `PROT_READ | PROT_EXEC` (and also a backup remap if the created region is not r-x and tries to remap it)